### PR TITLE
Replace deprecated add-path with core.addPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const core = require('@actions/core');
-const exec = require('@actions/exec');
 const tc = require('@actions/tool-cache');
 const io = require('@actions/io');
 
@@ -39,12 +38,12 @@ async function installTar(path, url) {
   await io.mkdirP(path);
   const downloadPath = await tc.downloadTool(url);
   await tc.extractTar(downloadPath, path);
-  await exec.exec('echo', [`::add-path::${path}`]);
+  core.addPath(path);
 }
 
 async function installZip(path, url) {
   await io.mkdirP(path);
   const downloadPath = await tc.downloadTool(url);
   await tc.extractZip(downloadPath, path);
-  await exec.exec('echo', [`::add-path::${path}`]);
+  core.addPath(path);
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/DopplerHQ/cli-action#readme",
   "dependencies": {
     "@actions/core": "^1.2.4",
-    "@actions/exec": "^1.0.4",
     "@actions/io": "^1.0.2",
     "@actions/tool-cache": "^1.5.5"
   }


### PR DESCRIPTION
We still need to upgrade the @actions/core package, but I will tackle that in a separate PR due to it blowing up every time I try.