### PR TITLE
Update NodeJS version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-18.04, macos-latest, windows-latest, windows-2016]
+        os: [ubuntu-latest, ubuntu-18.04, macos-latest, windows-latest, windows-2019]
     name: Install the cli
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The [Doppler CLI](https://github.com/DopplerHQ/cli) is the official tool for int
 Include this Action as a step in your workflow:
 
 ```
-uses: dopplerhq/cli-action@v1
+uses: dopplerhq/cli-action@v2
 ```
 
 You can see a live example of this Action [here](https://github.com/DopplerHQ/cli/blob/master/.github/workflows/cli-action.yml).
@@ -25,10 +25,10 @@ jobs:
   my-job:
     runs-on: ubuntu-latest
     steps:
-    - name: Install CLI
-      uses: dopplerhq/cli-action@v1
-    - name: Do something with the CLI
-      run: doppler secrets --only-names
-      env:
-        DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      - name: Install CLI
+        uses: dopplerhq/cli-action@v2
+      - name: Do something with the CLI
+        run: doppler secrets --only-names
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,6 @@ branding:
   icon: 'download'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-action",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cli-action",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "GitHub Action to install the Doppler CLI",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This moves the action to `node16` from `node12` in preparation for [GitHub moving all actions to Node16](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). I was going to update dependencies to the latest versions too, but ran into weird dependency conflicts, so leaving that be for the time being.