### PR TITLE
updating action to `node20` to address deprecation warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,6 @@ branding:
   icon: 'download'
   color: 'blue'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 


### PR DESCRIPTION
this will address warnings like these

<img width="1084" alt="image" src="https://github.com/DopplerHQ/cli-action/assets/5505280/5fadb609-3dc7-411a-a5e0-bce5128e6f79">
