### PR TITLE
fix: move bin dir outside workspace

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const tc = require('@actions/tool-cache');
 const io = require('@actions/io');
 const { execSync } = require('child_process');
 
-const workspace = process.env.GITHUB_WORKSPACE;
-const binDir = `${workspace}/bin`;
+const tempDir = process.env.RUNNER_TEMP;
+const binDir = `${tempDir}/doppler-cli-bin`;
 
 run().catch(error => {
   core.setFailed(error.message);


### PR DESCRIPTION
I think it's not nice that the bin dir is inside the workspace. It pollutes the folder, potentially conflicts with repo files, and I have a tool that checks for unknown files. I've moved it into the runner tmp dir.