### PR TITLE
BREAKING CHANGE: Update node to v24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,29 @@
+name: CI
+
 on: [push]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
 
 jobs:
   test_action:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macos-latest, macos-11, windows-latest, windows-2019]
+        os: [ubuntu-latest, ubuntu-22.04, ubuntu-24.04, macos-latest, macos-14, macos-15, windows-latest, windows-2022, windows-2025]
     name: Install the cli
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Install CLI
         uses: ./
-        id: install
       - name: Test CLI
         run: doppler --version
+      - name: Install CLI
+        uses: ./
+      - name: Test CLI Version Output
+        run: |
+          doppler --version

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,6 @@ branding:
   icon: 'download'
   color: 'blue'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
 


### PR DESCRIPTION
This pull request updates the CI workflow and action configuration to improve platform coverage and modernize dependencies. The main changes include expanding the matrix of operating systems for CI tests, updating GitHub Actions and Node.js versions, and enhancing workflow concurrency and permissions.

**CI Workflow Improvements:**

* Expanded the test matrix in `.github/workflows/main.yml` to include newer OS versions: `ubuntu-22.04`, `ubuntu-24.04`, `macos-14`, `macos-15`, `windows-2022`, and `windows-2025`, replacing some older versions.
* Upgraded `actions/checkout` from version 2 to version 6 for better performance and security.
* Added workflow concurrency control and set permissions to `read-all` to prevent duplicate runs and improve security.

**Dependency Updates:**

* Updated the action runtime in `action.yml` from `node20` to `node24` to use the latest Node.js version due to 
[upcoming deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)


⚠️ Should be considered as breaking as requires GitHub runner ([v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1)) ⚠️
