### PR TITLE
Add type: module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "description": "GitHub Action to install the Doppler CLI",
   "main": "index.js",
-  "module": "true",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Prevents [MODULE_TYPELESS_PACKAGE_JSON] warning on run.