### PR TITLE
Increase execution timeout limit to 120s from 30s

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -32593,7 +32593,7 @@ async function executeInstallSh(installPath) {
   // execute script
   await mkdirP(installPath);
   const installCommand = `${downloadPath} --debug --no-package-manager --install-path ${installPath}`;
-  execSync(installCommand, { timeout: 30000, stdio: "inherit" });
+  execSync(installCommand, { timeout: 120_000, stdio: "inherit" });
 
   // add binary to PATH
   addPath(installPath);

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ async function executeInstallSh(installPath) {
   // execute script
   await io.mkdirP(installPath);
   const installCommand = `${downloadPath} --debug --no-package-manager --install-path ${installPath}`
-  execSync(installCommand, { timeout: 30000, stdio: "inherit" });
+  execSync(installCommand, { timeout: 120_000, stdio: "inherit" });
 
   // add binary to PATH
   core.addPath(installPath);


### PR DESCRIPTION
The download command in the install script now retries up to 5 times with a 60s timeout each [1]. Since the current timeout is 30s, the download command can't retry even once if it gets stuck. Increasing it to 120s will give it more time to retry and complete the download.

[1]: https://github.com/DopplerHQ/cli/pull/517